### PR TITLE
Use Node's require in adapter

### DIFF
--- a/app/adapters/application.js
+++ b/app/adapters/application.js
@@ -1,8 +1,5 @@
 import DS from 'ember-data';
-// require('electron');
-import database from './database';
-
-// global.database = database;
+const database = requireNode('../database');
 
 export default DS.Adapter.extend({
 


### PR DESCRIPTION
Broccoli hijacks `require`, which normally isn't available in the browser, but it _is_ available in Electron applications. So, `ember-electron` aliases the built-in `require` to `requireNode`. This fixes the issue in #18.

[Here is a link](https://github.com/felixrieseberg/ember-electron#conflict-between-ember-and-electron-require) to the documentation.